### PR TITLE
fix: use admonition extension instead of callouts for mkdocs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Install mkdocs and dependencies
       run: |
         pip install mkdocs-material
-        pip install mkdocs-callouts
         pip install pymdown-extensions
 
     - name: Build documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,8 @@ plugins:
   - search
 
 markdown_extensions:
-  - callouts
+  - admonition
+  - pymdownx.details
   - pymdownx.snippets:
       base_path: !relative
       check_paths: true


### PR DESCRIPTION
## Summary
- Replace `callouts` markdown extension with `admonition` and `pymdownx.details`
- Remove `mkdocs-callouts` pip install (not needed)

The `mkdocs-callouts` package provides a plugin, not a markdown extension. Using the built-in admonition extension instead.

## Test plan
- [ ] Publish Docs workflow passes
- [ ] GitHub Pages shows mkdocs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)