### PR TITLE
fix: evaluate plutus exec units via ogmios so IsValid matches phase-2

### DIFF
--- a/off_chain/src/submitter.ts
+++ b/off_chain/src/submitter.ts
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { sleepMs } from './lib';
+import { Action, IEvaluator } from '@meshsdk/common';
 
 const connectWebSocket = async (address: string) => {
     return new Promise<WebSocket>((resolve, reject) => {
@@ -47,6 +48,7 @@ export type Client = {
     close: () => void;
     reply: (f: (string) => Promise<void>) => void;
     submitTx: (txHex: string) => void;
+    evaluateTx: (txHex: string) => void;
 };
 
 export const createClient = (client: WebSocket): Client => {
@@ -66,6 +68,13 @@ export const createClient = (client: WebSocket): Client => {
                 'submitTransaction',
                 { transaction: { cbor: txHex } },
                 'submitTransaction'
+            );
+        },
+        evaluateTx: (txHex: string) => {
+            rpc(
+                'evaluateTransaction',
+                { transaction: { cbor: txHex } },
+                'evaluateTransaction'
             );
         },
         reply: (f: (string) => Promise<void>) => {
@@ -89,6 +98,80 @@ export class TxSubmissionError extends Error {
         this.ogmiosError = ogmiosError;
     }
 }
+
+type OgmiosValidator = {
+    purpose:
+        | 'spend'
+        | 'mint'
+        | 'publish'
+        | 'withdraw'
+        | 'vote'
+        | 'propose';
+    index: number;
+};
+
+type OgmiosBudget = { memory: number; cpu: number };
+
+type OgmiosEvalEntry = {
+    validator: OgmiosValidator;
+    budget: OgmiosBudget;
+};
+
+const ogmiosPurposeToTag = (
+    p: OgmiosValidator['purpose']
+): Action['tag'] => {
+    switch (p) {
+        case 'spend':
+            return 'SPEND';
+        case 'mint':
+            return 'MINT';
+        case 'publish':
+            return 'CERT';
+        case 'withdraw':
+            return 'REWARD';
+        case 'vote':
+            return 'VOTE';
+        case 'propose':
+            return 'PROPOSE';
+    }
+};
+
+/**
+ * IEvaluator backed by ogmios `evaluateTransaction` (JSON-RPC over the
+ * same websocket the submitter uses). Bypasses yaci-store's evaluate
+ * proxy, which has been observed returning empty 500s on Plutus V3
+ * txs. Returns Mesh's redeemer-shape { tag, index, budget: {mem,steps} }.
+ */
+export const mkOgmiosEvaluator = (ogmios: string): IEvaluator => ({
+    evaluateTx: async (txHex: string) => {
+        const client = await connect(ogmios);
+        return new Promise<Omit<Action, 'data'>[]>((resolve, reject) => {
+            client.reply(async response => {
+                if (response.id !== 'evaluateTransaction') return;
+                if (response.error) {
+                    client.close();
+                    reject(
+                        new Error(
+                            `ogmios evaluateTransaction error: ${JSON.stringify(
+                                response.error
+                            )}`
+                        )
+                    );
+                    return;
+                }
+                const entries: OgmiosEvalEntry[] = response.result;
+                const actions: Omit<Action, 'data'>[] = entries.map(e => ({
+                    tag: ogmiosPurposeToTag(e.validator.purpose),
+                    index: e.validator.index,
+                    budget: { mem: e.budget.memory, steps: e.budget.cpu }
+                }));
+                client.close();
+                resolve(actions);
+            });
+            client.evaluateTx(txHex);
+        });
+    }
+});
 
 export const submitTransaction = async (
     ogmios,

--- a/off_chain/src/transactions/context.ts
+++ b/off_chain/src/transactions/context.ts
@@ -122,7 +122,7 @@ export const mkContext = (
         signingWallet: signingWallet,
         addressWallet: async (walletAddress: string) =>
             await observingWallet(walletAddress),
-        newTxBuilder: () => getTxBuilder(provider),
+        newTxBuilder: () => getTxBuilder(provider, ogmios),
         fetchTokens: async () => await state.tokens.getTokens(),
         fetchToken: async (tokenId: string) =>
             await state.tokens.getToken(tokenId),

--- a/off_chain/src/transactions/context/lib.ts
+++ b/off_chain/src/transactions/context/lib.ts
@@ -16,7 +16,13 @@ import { Context } from '../context';
 export function getTxBuilder(provider: Provider) {
     return new MeshTxBuilder({
         fetcher: provider,
-        submitter: provider
+        submitter: provider,
+        // Auto-correct plutus exec units via ogmios evaluateTransaction
+        // during complete() — replaces the hardcoded redeemer budgets
+        // with the actual phase-2 cost. Fixes #15 (IsValid mismatch on
+        // tokens whose trie depth pushes per-request cost above the
+        // hardcoded constants).
+        evaluator: provider
     });
 }
 

--- a/off_chain/src/transactions/context/lib.ts
+++ b/off_chain/src/transactions/context/lib.ts
@@ -12,8 +12,9 @@ import blueprint from '../../plutus.json';
 import { retry } from '../../test/lib';
 import { WalletInfo } from './wallet';
 import { Context } from '../context';
+import { mkOgmiosEvaluator } from '../../submitter';
 
-export function getTxBuilder(provider: Provider) {
+export function getTxBuilder(provider: Provider, ogmios: string) {
     return new MeshTxBuilder({
         fetcher: provider,
         submitter: provider,
@@ -21,8 +22,10 @@ export function getTxBuilder(provider: Provider) {
         // during complete() — replaces the hardcoded redeemer budgets
         // with the actual phase-2 cost. Fixes #15 (IsValid mismatch on
         // tokens whose trie depth pushes per-request cost above the
-        // hardcoded constants).
-        evaluator: provider
+        // hardcoded constants). We talk to ogmios directly rather than
+        // through yaci-store's evaluate proxy, which has been observed
+        // returning empty 500s on Plutus V3 txs.
+        evaluator: mkOgmiosEvaluator(ogmios)
     });
 }
 


### PR DESCRIPTION
## Summary

Closes #15.

`POST /transaction` (update-token submission) was 500ing on tokens with non-trivial trie state — the cfhal token (~970 facts, proof depth ~10) being today's repro. The unsigned tx was stamped with `IsValid: true` and hardcoded redeemer budgets (1 M / 1 G mem-steps for Modify, 200 k / 100 M for Contribute). Once per-request phase-2 cost grew past 100 M steps, ogmios rejected the tx as IsValid mismatch.

Fix: wire an `IEvaluator` into MeshTxBuilder so `complete()` auto-corrects the redeemer budgets with the actual phase-2 evaluated units before returning the unsigned tx.

## Why ogmios directly, not yaci-store

The first attempt routed evaluation through `provider.evaluateTx` (the YaciProvider/BlockfrostProvider implementation). Yaci-store's HTTP `/evaluate` proxy returns empty 500s on Plutus V3 txs in our stack:

```
{"data":{"status_code":500,"error":"Internal Server Error","message":"Error evaluating tx: "}}
```

So the second commit replaces it with `mkOgmiosEvaluator` — a tiny `IEvaluator` that talks to ogmios's `evaluateTransaction` JSON-RPC over the same websocket the submitter already uses, and translates ogmios's `{validator: {purpose, index}, budget: {memory, cpu}}` into Mesh's `{tag, index, budget: {mem, steps}}`. No new infrastructure dependency; we already had ogmios in the stack.

## Changes

- `off_chain/src/submitter.ts` — adds `mkOgmiosEvaluator(ogmios)` and a small `evaluateTx` JSON-RPC helper on the existing `Client`. The `OgmiosValidator.purpose` → `RedeemerTagType` map handles all six purposes (note: ogmios `withdraw` maps to Mesh's `REWARD`, not `WITHDRAWAL`).
- `off_chain/src/transactions/context/lib.ts` — `getTxBuilder` now takes the ogmios URL and wires `evaluator: mkOgmiosEvaluator(ogmios)` into `MeshTxBuilder`.
- `off_chain/src/transactions/context.ts` — threads `ogmios` through the existing `mkContext(ogmios, ...)` parameter into `newTxBuilder`. No public API change to `Context`.

The hardcoded constants in `transactions/update.ts` are kept as the *initial* values passed to `txInRedeemerValue` (Mesh requires a budget there), but `complete()` overwrites them with the evaluated units before re-serialising.

## Verified live

Side instance `mpfs-issue-14` on production, fed the cfhal token's three pending requests:

```
tx_build_start   request_id=41ef7525… token_id=21c523c3…069b requireds_count=3
tx_build_ok      txid=71598181…74d69 unsigned_tx_size=15270
tx_submit_start  txid=71598181…74d69 validity_tag=true
tx_submit_ok     txid=71598181…74d69
```

Note the txid differs from the previous-broken build's `e11a6f9d…9d2e` because the redeemer budgets are now real numbers, so the body hash changes.

## Reviewer notes

- All five tx-build call sites (boot, request, update, retract, end) flow through `getTxBuilder` and therefore all benefit from auto-evaluation. No per-endpoint changes needed.
- The structured submit-error path from #14 still works: if ogmios's evaluator rejects the unsigned tx, the wrapping evaluator throws `ogmios evaluateTransaction error: <full JSON>` and the surrounding `tx_build_failed` log captures it intact.
- This PR is the canonical option (1) from #15. Options (2) "scale by trie depth" and (3) "raise the constants" are no longer needed.

## Test plan

- [x] cfhal update-token with 3 pending requests builds + submits without IsValid mismatch (reproduced live).
- [x] tx_build_ok / tx_submit_ok logs share the same txid for end-to-end correlation.
- [ ] Boot, request, retract, end paths still build (auto-evaluator is on the same builder; smoke test welcome).