### PR TITLE
docs: review and correct documentation against the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# Repository Agent Guide
+
+## What this repo is
+
+MPFS (Merkle Patricia Forestry Service) is a Cardano-native HTTP service for
+verifiable key-value stores. It has two halves: an **on-chain** Aiken validator
+under `on_chain/` (the "cage" that mints MPF tokens and validates `boot`,
+`update`, `end`, and `retract`), and an **off-chain** TypeScript service under
+`off_chain/` that builds those transactions, indexes the chain via Ogmios, and
+serves everything over HTTP. The service is *signingless*: every endpoint
+returns an unsigned CBOR transaction that the caller signs and submits back. It
+targets Cardano preprod and is a proof of concept.
+
+## How to work here
+
+The toolchain comes from the Nix dev shell; tasks run through `just`.
+
+```bash
+nix develop                 # Node.js/npm, Aiken, cardano-node/cli, yaci, mkdocs
+
+just build-on-chain         # cd on_chain && aiken build
+just check-on-chain         # cd on_chain && aiken check
+just build-off-chain        # copy on_chain/plutus.json into off_chain, npm install
+just test-all               # off-chain test suite (ava + vitest); needs Yaci + Ogmios
+just format                 # prettier over off_chain/**/*.ts
+
+mkdocs build --strict       # build the docs site (docs_dir: docs-mkdocs/)
+```
+
+Running the service from source:
+
+```bash
+cd off_chain && npm install
+npx tsx src/service/signingless/main.ts --port 3000 \
+    --provider yaci --yaci-store-host http://localhost:8080 \
+    --ogmios-host http://localhost:1337 --database-path ./mpfs.db
+```
+
+Tests need Yaci Store (`:8080`), Yaci admin (`:10000`), and Ogmios (`:1337`)
+running — `just run-yaci` / `just run-yaci-docker` start the Yaci devkit, or use
+`just test-docker` to run the whole suite against a throwaway container.
+
+Scope notes for agents:
+
+- The state store is **LevelDB** (the `level` / `abstract-level` packages), not
+  a SQL database.
+- Only the **signingless** service is current. `off_chain/src/service/cli`
+  still imports a removed `signing/` module and does not run; do not present it
+  as a working CLI.
+- API request bodies: insert takes `{key, newValue}`, delete takes
+  `{key, oldValue}`, update takes `{key, oldValue, newValue}` (renamed in
+  v1.1.0). The served `openapi.json` still advertises a `{key, value}` body for
+  insert/delete and is out of date relative to the handlers in
+  `off_chain/src/service/signingless/http.ts`.
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose description
+matches your task:
+
+- `skills/mpfs-guide/` — how MPFS is laid out, how to build/test/run it, where
+  the HTTP endpoints and on-chain operations are implemented, and where the
+  answers to common user questions live.

--- a/README.md
+++ b/README.md
@@ -3,43 +3,88 @@
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://cardano-foundation.github.io/mpfs/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green)](LICENSE)
 
-MPFS is a Cardano-native service for managing verifiable key-value stores using Merkle Patricia Forestry (MPF) data structures on-chain.
+MPFS is a Cardano-native HTTP service for managing verifiable key-value stores
+using [Merkle Patricia Forestry](https://github.com/aiken-lang/merkle-patricia-forestry)
+(MPF) tries on-chain.
 
-## Overview
+## What is this
 
-MPFS enables:
+A Merkle Patricia Forestry stores key-value pairs (facts) so that anyone can
+prove a fact is or is not in the set from a single root hash. MPFS puts that
+root hash inside a Cardano UTxO and lets an owner (the *oracle*) evolve it by
+accepting change requests from contributors, all under smart-contract
+validation. Because every modification appears on-chain, the full history — and
+therefore the current facts — is reconstructable by anyone with access to the
+chain, and each fact can be referenced as a transaction input in other
+contracts.
 
-- **Verifiable Data Storage**: Store key-value pairs (facts) with cryptographic proofs of inclusion/exclusion
-- **On-chain Validation**: All modifications are validated by Cardano smart contracts
-- **Decentralized Knowledge**: Build dApps, knowledge bases, and collaborative platforms with immutable history
+MPFS bundles three things:
+
+- An **on-chain validator** (Aiken) — the "cage" — that mints MPF tokens and
+  validates every `boot`, `update`, `end`, and `retract` operation.
+- An **off-chain TypeScript service** that builds the transactions for those
+  operations and exposes them over HTTP.
+- An **indexer** that follows the chain (via Ogmios) to reconstruct and serve
+  the state and facts of every token.
+
+The service is **signingless**: every endpoint returns an *unsigned* CBOR
+transaction that the caller signs with their own wallet and submits back. It is
+a proof of concept and currently targets Cardano **preprod** only.
 
 ## Architecture
 
-```
-┌─────────────┐     ┌─────────────────┐     ┌────────────────┐
-│   Client    │────▶│   MPFS Service  │────▶│    Cardano     │
-│  (Wallet)   │     │  (TypeScript)   │     │   Blockchain   │
-└─────────────┘     └─────────────────┘     └────────────────┘
-                            │
-                    ┌───────┴───────┐
-                    ▼               ▼
-            ┌───────────┐   ┌───────────────┐
-            │  Indexer  │   │  Trie Manager │
-            │ (Ogmios)  │   │    (MPF)      │
-            └───────────┘   └───────────────┘
+```mermaid
+flowchart LR
+    Wallet["Client wallet<br/>(signs CBOR)"]
+
+    subgraph Service["MPFS service (TypeScript)"]
+        API["HTTP API<br/>(Express)"]
+        TxBuilder["Transaction builder<br/>(Mesh SDK)"]
+        Indexer["Chain indexer"]
+        Trie["Trie manager<br/>(MPF)"]
+        DB[("LevelDB")]
+    end
+
+    subgraph External["External services"]
+        Yaci["Yaci Store<br/>(address &rarr; UTxO)"]
+        Ogmios["Ogmios<br/>(chain sync + submit)"]
+    end
+
+    Node["Cardano node"]
+
+    Wallet -->|address, signed tx| API
+    API --> TxBuilder
+    API --> Indexer
+    TxBuilder --> Trie
+    Trie --> DB
+    Indexer --> DB
+    TxBuilder --> Yaci
+    Indexer --> Ogmios
+    TxBuilder -->|submit| Ogmios
+    Yaci --> Node
+    Ogmios --> Node
 ```
 
-## Quick Start
+## Install
 
-### Using Docker
+A pre-built image is published to the GitHub Container Registry:
 
 ```bash
-docker pull ghcr.io/cardano-foundation/mpfs/mpfs:v1.1.0
+docker pull ghcr.io/cardano-foundation/mpfs/mpfs:v1.3.0
 ```
 
-See the [deployment guide](https://github.com/cardano-foundation/hal/blob/main/docs/deployment/mpfs/README.md) for full setup instructions.
+See the [Cardano Foundation deployment guide](https://github.com/cardano-foundation/hal/blob/main/docs/deployment/mpfs/README.md)
+for a full `docker-compose` setup (node + Yaci Store + Ogmios + MPFS).
 
-### From Source
+A public preprod instance is hosted at [mpfs.plutimus.com](https://mpfs.plutimus.com)
+— free to use, with no availability guarantees. Run your own instance if you
+intend to control MPF tokens.
+
+## Quickstart
+
+The service needs a running [Yaci Store](https://github.com/bloxbean/yaci-store)
+(address → UTxO mapping) and [Ogmios](https://github.com/cardanoSolutions/ogmios)
+(chain events). To run it from source:
 
 ```bash
 git clone https://github.com/cardano-foundation/mpfs
@@ -53,75 +98,92 @@ npx tsx src/service/signingless/main.ts --port 3000 \
     --since-block-id ef94934f8eb129ebf07eeaab007b81ecb1bc58b121d19ac0ffe81f928bf56cc
 ```
 
-### Development with Nix
+`--since-slot` / `--since-block-id` set where indexing starts; start from a
+point *before* the token you care about was created (for a fresh token, "now"
+is fine). See the [Getting Started guide](https://cardano-foundation.github.io/mpfs/getting-started/)
+for the full option list and a Docker-based setup.
 
-```bash
-nix develop
-```
+## Usage
 
-This provides all development tools including:
-- Node.js and npm
-- Aiken (smart contract language)
-- Cardano node and CLI tools
-- mkdocs for documentation
+Every transaction endpoint returns an unsigned CBOR transaction under
+`unsignedTransaction`; sign it with your wallet and submit it back via
+`POST /transaction`. Request bodies follow the on-chain operation: insert takes
+`newValue`, delete takes `oldValue`, update takes both.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/tokens` | GET | List all MPF tokens |
+| `/token/{tokenId}` | GET | Token state and pending requests |
+| `/token/{tokenId}/facts` | GET | All facts stored in a token |
+| `/config` | GET | Cage script address, policy id, blueprint |
+| `/transaction/{address}/boot-token` | GET | Build a tx to create a new token |
+| `/transaction/{address}/request-insert/{tokenId}` | POST | Request to insert a fact (`{key, newValue}`) |
+| `/transaction/{address}/request-delete/{tokenId}` | POST | Request to delete a fact (`{key, oldValue}`) |
+| `/transaction/{address}/request-update/{tokenId}` | POST | Request to update a fact (`{key, oldValue, newValue}`) |
+| `/transaction/{address}/update-token/{tokenId}` | GET | Process pending requests |
+| `/transaction/{address}/retract-change/{requestId}` | GET | Retract a pending request |
+| `/transaction/{address}/end-token/{tokenId}` | GET | Destroy a token |
+| `/transaction` | POST | Submit a signed transaction |
+
+The full surface, with worked end-to-end examples, is in the
+[Signingless Manual](https://cardano-foundation.github.io/mpfs/manual/signingless/)
+and the live Swagger UI at [mpfs.plutimus.com/api-docs](https://mpfs.plutimus.com/api-docs).
 
 ## Documentation
 
-Full documentation is available at [cardano-foundation.github.io/mpfs](https://cardano-foundation.github.io/mpfs/).
+Full documentation is published at
+[cardano-foundation.github.io/mpfs](https://cardano-foundation.github.io/mpfs/).
 
-### Building Docs Locally
+For AI agents, start at [AGENTS.md](AGENTS.md).
+
+## Development
+
+The Nix dev shell provides Node.js/npm, Aiken, the Cardano node/CLI tooling,
+Yaci CLI, and mkdocs:
 
 ```bash
 nix develop
-mkdocs serve
 ```
 
-Then open http://localhost:8000 in your browser.
+Common tasks are driven through [`just`](justfile):
+
+```bash
+just build-on-chain     # aiken build
+just check-on-chain     # aiken check
+just build-off-chain    # copy plutus.json into off_chain, npm install
+just test-all           # run the off-chain test suite (needs Yaci + Ogmios)
+```
+
+Build the docs site locally:
+
+```bash
+nix develop
+mkdocs serve   # then open http://localhost:8000
+```
 
 ## Project Structure
 
 ```
 mpfs/
-├── on_chain/           # Aiken smart contracts
-│   └── validators/     # Cage validator and types
-├── off_chain/          # TypeScript service
+├── on_chain/              # Aiken smart contract (the "cage")
+│   └── validators/        # cage.ak, types.ak, lib.ak
+├── off_chain/             # TypeScript service
 │   └── src/
-│       ├── service/    # HTTP API (signingless/signingful)
-│       ├── transactions/ # Transaction builders
-│       ├── indexer/    # Chain event indexer
-│       └── trie/       # MPF trie management
-├── docs-mkdocs/        # Documentation (mkdocs)
-└── flake.nix           # Nix development environment
+│       ├── service/       # HTTP API (signingless), wallet + cli helpers
+│       ├── transactions/  # boot / request / update / retract / end builders
+│       ├── indexer/       # Ogmios-driven chain indexer + state
+│       ├── trie/          # MPF trie management and proofs
+│       └── mpf/           # vendored Merkle Patricia Forestry library
+├── docs-mkdocs/           # documentation site (mkdocs, built by CI)
+├── flake.nix              # Nix development environment
+└── justfile               # task runner
 ```
-
-## API
-
-A public preprod instance is available at [mpfs.plutimus.com](https://mpfs.plutimus.com).
-
-See the [API Reference](https://cardano-foundation.github.io/mpfs/swagger-ui/) for full documentation.
-
-### Key Endpoints
-
-| Endpoint | Description |
-|----------|-------------|
-| `GET /tokens` | List all MPF tokens |
-| `GET /token/{id}` | Get token state and requests |
-| `GET /token/{id}/facts` | Get all facts in a token |
-| `GET /transaction/{addr}/boot-token` | Create a new token |
-| `POST /transaction/{addr}/request-insert/{id}` | Request to insert a fact |
-| `GET /transaction/{addr}/update-token/{id}` | Process pending requests |
 
 ## Dependencies
 
-- [Yaci Store](https://github.com/bloxbean/yaci-store) - Address to UTxO mapping
-- [Ogmios](https://github.com/cardanoSolutions/ogmios) - Chain event tracking
-- [Cardano Node](https://github.com/intersectMBO/cardano-node) - Blockchain access
-
-## Code Tracking
-
-We use [Radicle](https://radicle.xyz/) for decentralized code tracking:
-
-[rad:zpZ4szHxvnyVyDiy2acfcVEzxza9](https://app.radicle.xyz/nodes/seed.radicle.garden/rad:zpZ4szHxvnyVyDiy2acfcVEzxza9)
+- [Yaci Store](https://github.com/bloxbean/yaci-store) — address to UTxO mapping
+- [Ogmios](https://github.com/cardanoSolutions/ogmios) — chain event tracking and submission
+- [Cardano Node](https://github.com/intersectMBO/cardano-node) — blockchain access
 
 ## See Also
 
@@ -129,7 +191,8 @@ We use [Radicle](https://radicle.xyz/) for decentralized code tracking:
 - [Merkle Patricia Forestry Library](https://github.com/aiken-lang/merkle-patricia-forestry)
 - [Cardano Foundation](https://github.com/cardano-foundation)
 - [About Cardano](https://cardano.org/)
+- Decentralized code tracking on [Radicle](https://radicle.xyz/): [rad:zpZ4szHxvnyVyDiy2acfcVEzxza9](https://app.radicle.xyz/nodes/seed.radicle.garden/rad:zpZ4szHxvnyVyDiy2acfcVEzxza9)
 
 ## License
 
-Apache 2.0
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/docs-mkdocs/code/off-chain.md
+++ b/docs-mkdocs/code/off-chain.md
@@ -26,13 +26,15 @@ type Context = {
   fetchTokens: () => Promise<Token[]>;
   fetchToken: (tokenId: string) => Promise<CurrentToken | undefined>;
   fetchRequests: (tokenId: string | null) => Promise<Request[]>;
+  evaluate: (txHex: string) => Promise<any>;
   trie: (tokenId: string, f: (trie: SafeTrie) => Promise<any>) => Promise<void>;
   waitBlocks: (n: number) => Promise<number>;
   tips: () => Promise<{ networkTip, indexerTip }>;
   waitSettlement: (txHash: string) => Promise<string>;
+  facts: (tokenId: string) => Promise<Record<string, ValueSlotted>>;
   pauseIndexer: () => Promise<() => void>;
   submitTx: (txHex: string) => Promise<string>;
-  // ...
+  txInfo: (txHash: string) => Promise<any | null>;
 };
 ```
 
@@ -182,7 +184,7 @@ flowchart TB
         TxBuilder[Transaction Builder]
         Indexer[Chain Indexer]
         TrieManager[Trie Manager]
-        State[(SQLite State)]
+        State[(LevelDB State)]
     end
 
     subgraph External

--- a/docs-mkdocs/code/on-chain.md
+++ b/docs-mkdocs/code/on-chain.md
@@ -13,43 +13,53 @@ The cage smart contract manages MPF (Merkle Patricia Forestry) tokens on Cardano
 Defines the core data types used throughout the contract:
 
 #### `Mint`
-Represents the type of minting operation:
-- `Boot` - Creates a new MPF token with an empty root
-- `Destroy` - Burns an existing MPF token
+Parameters for minting a new caged token. The `asset` output reference must be
+one of the transaction inputs; its hash becomes the token's asset name,
+guaranteeing uniqueness:
+```aiken
+type Mint {
+  asset: OutputReference,
+}
+```
 
 #### `MintRedeemer`
-Redeemer for minting policy validation:
+Redeemer for the minting policy:
 ```aiken
 type MintRedeemer {
-  Boot { token: TokenId }
-  Destroy
+  Minting(Mint)  // Mint a new caged token
+  Burning        // Burn an existing caged token (no extra validation)
 }
 ```
 
 #### `UpdateRedeemer`
-Redeemer for spending validator (state updates):
+Redeemer for spending caged UTxOs. The available action depends on whether the
+UTxO carries a `State` or a `Request` datum (constructor order matters — it is
+the on-chain `ConStr` index):
 ```aiken
 type UpdateRedeemer {
-  proofs: List<Proof>
+  End                       // ConStr0: destroy the caged token (State datum)
+  Contribute(OutputReference) // ConStr1: link a request to a State UTxO (Request datum)
+  Modify(List<Proof>)       // ConStr2: fold requests into the MPF (State datum)
+  Retract                   // ConStr3: reclaim a Request UTxO (Request datum)
 }
 ```
 
 #### `State`
-Represents the current state of an MPF token:
+The state of a caged token, stored as an inline datum:
 ```aiken
 type State {
-  owner: ByteArray,  // Public key hash of the owner
-  root: Hash<Blake2b_256, ByteArray>  // Current MPF root hash
+  owner: VerificationKeyHash,  // Public key hash of the owner
+  root: ByteArray,             // Current MPF root hash
 }
 ```
 
 #### `Operation`
-Defines the operations that can be applied to an MPF:
+The operations that can be applied to the MPF. Variants are positional:
 ```aiken
 type Operation {
-  Insert { new_value: ByteArray }
-  Delete { old_value: ByteArray }
-  Update { old_value: ByteArray, new_value: ByteArray }
+  Insert(ByteArray)            // new value
+  Delete(ByteArray)            // expected (old) value
+  Update(ByteArray, ByteArray) // (old_value, new_value)
 }
 ```
 
@@ -57,40 +67,43 @@ type Operation {
 A pending modification request:
 ```aiken
 type Request {
-  tokenId: TokenId,     // Target token identifier
-  owner: ByteArray,     // Request owner's pub key hash
-  key: ByteArray,       // MPF key to modify
-  operation: Operation  // The requested operation
+  requestToken: TokenId,            // Target token (by asset name)
+  requestOwner: VerificationKeyHash, // Request owner (can Retract)
+  requestKey: ByteArray,            // MPF key to modify
+  requestValue: Operation,          // The requested operation
 }
 ```
 
 #### `CageDatum`
-The datum type for UTxOs at the cage address:
+The datum type for UTxOs at the cage address. Variants are positional:
 ```aiken
 type CageDatum {
-  RequestDatum { request: Request }  // A pending request
-  StateDatum { state: State }        // Token state
+  RequestDatum(Request)  // A pending request
+  StateDatum(State)      // Token state
 }
 ```
 
 ### `lib.ak`
 
-Helper functions for token manipulation:
+Helper functions for token handling. `TokenId` is defined here as a wrapper
+around an `AssetName`:
 
-#### `quantity(value, policy, name)`
-Extracts the quantity of a specific asset from a Value.
+#### `quantity(policyId: PolicyId, value: Value, TokenId) -> Option<Int>`
+Returns the quantity of the given token in a value, or `None` if absent.
 
-#### `assetName(value, policy)`
-Retrieves the asset name of the first token found for a given policy.
+#### `assetName(ref: OutputReference) -> Hash<Sha2_256, OutputReference>`
+Computes a unique asset name as the SHA2-256 hash of the transaction id
+concatenated with the output index (2 big-endian bytes).
 
-#### `valueFromToken(policy, name, quantity)`
-Creates a Value containing the specified token.
+#### `valueFromToken(policyId: PolicyId, TokenId) -> Value`
+Constructs a value holding exactly one of the given token.
 
-#### `tokenFromValue(value, policy)`
-Extracts token information (name and quantity) from a Value.
+#### `tokenFromValue(value: Value) -> Option<TokenId>`
+Extracts the single non-ADA token from a value, or `None` if it does not hold
+exactly one policy with exactly one asset name.
 
-#### `extractTokenFromInputs(inputs, policy)`
-Finds and extracts a token from a list of transaction inputs.
+#### `extractTokenFromInputs(what: OutputReference, inputs: List<Input>)`
+Finds the input matching the output reference and extracts its single token.
 
 ### `cage.ak`
 
@@ -100,7 +113,7 @@ The main validator implementing both minting policy and spending validator.
 
 The minting policy controls token creation and destruction:
 
-### Boot (Minting)
+### `Minting` (boot)
 When creating a new token:
 1. The token ID must be unique (derived from a spent UTxO)
 2. Exactly one token is minted
@@ -109,10 +122,11 @@ When creating a new token:
    - A null (empty) MPF root
    - The signer as the owner
 
-### Destroy (Burning)
+### `Burning` (end)
 When destroying a token:
 1. The token is burned (quantity: -1)
-2. The owner must sign the transaction
+2. No additional validation runs in the minting policy; the spending validator's
+   `End` case enforces owner signature when the State UTxO is consumed
 
 ## Spending Validator
 

--- a/docs-mkdocs/getting-started.md
+++ b/docs-mkdocs/getting-started.md
@@ -17,7 +17,7 @@ The MPFS service in itself is a TypeScript application so any Node.js supported 
 The image is available on ghcr.io and can be pulled with the command:
 
 ```bash
-docker pull ghcr.io/cardano-foundation/mpfs/mpfs:v1.1.0
+docker pull ghcr.io/cardano-foundation/mpfs/mpfs:v1.3.0
 ```
 
 This is an example of a working deployment: [mpfs in CF](https://github.com/cardano-foundation/hal/blob/main/docs/deployment/mpfs/docker-compose.yml)
@@ -30,7 +30,7 @@ Alternatively, you can run the service from source. To do so, you need to have N
 
 ```bash
 git clone https://github.com/cardano-foundation/mpfs
-cd off_chain
+cd mpfs/off_chain
 npm install
 npx tsx src/service/signingless/main.ts --port 3000 \
     --provider yaci --yaci-store-host http://localhost:8080 \
@@ -49,4 +49,3 @@ This will start the service on port 3000, using the Yaci store running on `http:
 
 - [Signingless API Reference](swagger-ui.md)
 - [Signingless Manual](manual/signingless.md)
-- [Signingful Manual](manual/signingful.md)

--- a/docs-mkdocs/index.md
+++ b/docs-mkdocs/index.md
@@ -31,7 +31,12 @@ It is designed to be used by anyone who wants to store and manage knowledge in a
 
 It is particularly useful for applications that require a verifiable and immutable record of knowledge, such as decentralized applications (dApps), knowledge management systems, and collaborative platforms.
 
-The service comes in 2 flavors: signingful and signingless. The signingful version is suitable for local installations where it controls a private key for the user, while the signingless version is suitable for remote installations where the user has to provide a signature for each transaction.
+The repository ships the **signingless** service: it builds and balances
+transactions and delegates signing to the caller. Every endpoint returns an
+unsigned CBOR transaction that the user signs locally and submits back, so the
+service never holds a private key. This makes it suitable for shared, public
+deployments — the operator only has to protect the instance from abuse, not
+custody anyone's keys.
 
 ## Quick Links
 

--- a/docs-mkdocs/manual/signingless.md
+++ b/docs-mkdocs/manual/signingless.md
@@ -161,6 +161,11 @@ For the sake of the manual we are not going to impersonate different roles, but 
 
 A fact in this context is a key-value pair. MPFS imposes no semantics so you are free to pass a JSON string for both. In case of binary data some encoding could be necessary, MPFS is not supporting any at the moment.
 
+The request body field carrying the value depends on the operation: insert
+takes `newValue`, delete takes `oldValue`, and update takes both `oldValue` and
+`newValue` (these names changed in v1.1.0 — older `value` payloads no longer
+work).
+
 You can ask the owner to insert a fact with:
 
 ```bash
@@ -170,7 +175,7 @@ result=$(curl -s -X 'POST' \
   -H 'Content-Type: application/json' \
   -d '{
   "key": "exampleKey",
-  "value": "exampleValue"
+  "newValue": "exampleValue"
    }')
 echo $result | jq -r '.unsignedTransaction' > tmp/tx.cbor
 txId=$(sign_and_submit)
@@ -218,7 +223,7 @@ result=$(curl -s -X 'POST' \
   -H 'Content-Type: application/json' \
   -d '{
   "key": "exampleKey",
-  "value": "exampleValue"
+  "newValue": "exampleValue"
    }')
 echo $result | jq -r '.unsignedTransaction' > tmp/tx.cbor
 txId=$(sign_and_submit)
@@ -305,7 +310,7 @@ result=$(curl -s -X 'POST' \
   -H 'Content-Type: application/json' \
   -d '{
   "key": "exampleKey",
-  "value": "newExampleValue"
+  "oldValue": "newExampleValue"
    }')
 echo $result | jq -r '.unsignedTransaction' > tmp/tx.cbor
 txId=$(sign_and_submit)

--- a/docs-mkdocs/swagger-ui.md
+++ b/docs-mkdocs/swagger-ui.md
@@ -44,8 +44,11 @@ All transaction endpoints return unsigned CBOR transactions that must be signed 
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/tips` | GET | Get current network and indexer tips |
-| `/wait/{nBlocks}` | GET | Wait for specified number of blocks |
+| `/wait/{nBlocks}` | GET | Wait for the given number of blocks |
+
+The current network and indexer tips are returned alongside the token list by
+`GET /tokens` (in the `indexerStatus` field); there is no standalone `/tips`
+endpoint.
 
 ## Authentication
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,18 @@ docs_dir: docs-mkdocs
 theme:
   name: material
   palette:
-    scheme: slate
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - navigation.indexes
     - toc.integrate

--- a/skills/mpfs-guide/SKILL.md
+++ b/skills/mpfs-guide/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: mpfs-guide
+description: >-
+  Orient an agent inside the cardano-foundation/mpfs repository (Merkle Patricia
+  Forestry Service). Load this when working on MPFS: the Aiken "cage" validator
+  in on_chain/ (cage.ak, types.ak, lib.ak; mpfCage minting + spending,
+  MintRedeemer Minting/Burning, UpdateRedeemer End/Contribute/Modify/Retract,
+  Operation Insert/Delete/Update), or the off-chain TypeScript service in
+  off_chain/ (Express HTTP API in src/service/signingless/http.ts, transaction
+  builders in src/transactions/{boot,request,update,retract,end}.ts, the
+  Ogmios-driven indexer in src/indexer/, the MPF trie manager in src/trie/, and
+  the wallet/cli helpers in src/service/). Use it for questions about the HTTP
+  endpoints (/tokens, /token/{id}, /token/{id}/facts, /config, boot-token,
+  request-insert, request-delete, request-update, update-token, retract-change,
+  end-token, POST /transaction), the request body fields (newValue / oldValue),
+  building/testing with nix develop + just + aiken + ava/vitest, running the
+  signingless service with tsx, Yaci Store / Ogmios / cardano-node dependencies,
+  LevelDB state, or the mkdocs docs under docs-mkdocs/. Keywords: MPF, oracle,
+  requester, caged token, signingless, plutus.json, mpfs.plutimus.com.
+---
+
+# MPFS guide
+
+MPFS manages verifiable key-value stores (facts) on Cardano. An owner (the
+*oracle*) controls an MPF token whose datum holds a Merkle Patricia Forestry
+root; contributors (*requesters*) submit change requests; the oracle folds them
+into the root under smart-contract validation. The service is signingless — it
+returns unsigned CBOR that the caller signs and submits back.
+
+## Repository map
+
+| Path | Purpose |
+| --- | --- |
+| `on_chain/validators/cage.ak` | The `mpfCage` validator: minting policy + spending validator |
+| `on_chain/validators/types.ak` | On-chain types: `Mint`, `MintRedeemer`, `UpdateRedeemer`, `State`, `Operation`, `Request`, `CageDatum` |
+| `on_chain/validators/lib.ak` | `TokenId` + token helpers (`quantity`, `assetName`, `valueFromToken`, `tokenFromValue`, `extractTokenFromInputs`) |
+| `on_chain/plutus.json` | Compiled blueprint; copied to `off_chain/src/plutus.json` by `just build-off-chain` |
+| `off_chain/src/service/signingless/` | The shipped service: `main.ts` (CLI entry), `http.ts` (Express routes), `public/openapi.json` |
+| `off_chain/src/service/wallet.ts` | Local wallet helper: `create-wallet`, `reveal-address`, `sign-transaction` |
+| `off_chain/src/service/cli/` | Interactive REPL client — imports a removed `signing/` module; does not run |
+| `off_chain/src/transactions/` | Transaction builders: `boot.ts`, `request.ts`, `update.ts`, `retract.ts`, `end.ts`, plus `context.ts` |
+| `off_chain/src/indexer/` | Ogmios-driven indexer and on-disk state (tokens, requests, rollbacks, checkpoints) |
+| `off_chain/src/trie/` | MPF trie manager and proof generation (`safeTrie.ts`, `proof.ts`, `change.ts`) |
+| `off_chain/src/mpf/` | Vendored `merkle-patricia-forestry` JS library |
+| `docs-mkdocs/` | Documentation site (mkdocs; `docs_dir` in `mkdocs.yml`), published by `.github/workflows/publish-docs.yml` |
+| `docs/` | Abandoned Docusaurus scaffold — not built or published; ignore it |
+
+## Build, test, run
+
+All tools come from `nix develop`; tasks run through `just` (see `justfile`).
+
+```bash
+nix develop
+just check-on-chain      # aiken check (on_chain/)
+just build-on-chain      # aiken build (on_chain/)
+just build-off-chain     # copy plutus.json into off_chain, npm install
+just test-all            # ava + vitest; needs Yaci Store/admin + Ogmios up
+just format              # prettier over off_chain/**/*.ts
+mkdocs build --strict    # build the docs site
+```
+
+Tests expect Yaci Store on `:8080`, Yaci admin on `:10000`, Ogmios on `:1337`.
+`just run-yaci` (or `just run-yaci-docker`) starts the Yaci devkit; `just
+test-docker` runs the whole suite against a throwaway container.
+
+Run the service from source:
+
+```bash
+cd off_chain && npm install
+npx tsx src/service/signingless/main.ts --port 3000 \
+    --provider yaci --yaci-store-host http://localhost:8080 \
+    --ogmios-host http://localhost:1337 --database-path ./mpfs.db \
+    --since-slot <slot> --since-block-id <block-hash>
+```
+
+CLI flags are defined in `src/service/signingless/main.ts` (`--port`,
+`--provider blockfrost|yaci`, `--blockfrost-project-id`, `--yaci-store-host`,
+`--yaci-admin-host`, `--ogmios-host`, `--database-path`, `--logs-path`,
+`--since-slot`, `--since-block-id`). State is stored in LevelDB at
+`<database-path>/<port>`.
+
+## Navigating the code
+
+- **HTTP endpoints**: every route is registered in `mkAPI()` in
+  `off_chain/src/service/signingless/http.ts`. Each transaction route delegates
+  to a builder in `src/transactions/` and returns `{ unsignedTransaction, ... }`.
+- **Transaction building**: start at `src/transactions/context.ts` (`Context`
+  bundles script info, wallet access, state queries, trie access, submit). Each
+  operation has its own module (`boot.ts`, `request.ts`, `update.ts`,
+  `retract.ts`, `end.ts`).
+- **On-chain validation**: `on_chain/validators/cage.ak`. `mint` dispatches on
+  `MintRedeemer` (`Minting`/`Burning`); `spend` dispatches on `UpdateRedeemer`
+  (`Retract`, `Contribute`, then `Modify`/`End` for State datums). The MPF fold
+  lives in `mkUpdate` / `validRootUpdate`.
+- **Indexer & state**: `src/indexer/indexer.ts` consumes Ogmios chain-sync;
+  `src/indexer/state/` holds tokens, requests, rollbacks, and checkpoints.
+- **Proofs**: `src/trie/safeTrie.ts` applies a change to a local trie copy,
+  captures the proof, and rolls back; `update.ts` uses this for the `Modify`
+  redeemer.
+
+## Using MPFS (the HTTP API)
+
+Base URL of the public preprod instance: `https://mpfs.plutimus.com`. All
+transaction endpoints return `unsignedTransaction` (CBOR) to be signed and
+submitted via `POST /transaction`.
+
+| Method | Path | Body / notes |
+| --- | --- | --- |
+| GET | `/tokens` | lists tokens; includes `indexerStatus` (tips) |
+| GET | `/token/{tokenId}` | token state + pending `requests` |
+| GET | `/token/{tokenId}/facts` | all facts in the token's MPF |
+| GET | `/config` | cage address, policyId, blueprint |
+| GET | `/transaction/{address}/boot-token` | returns `{unsignedTransaction, value}` (value = new token id) |
+| POST | `/transaction/{address}/request-insert/{tokenId}` | `{ "key", "newValue" }` |
+| POST | `/transaction/{address}/request-delete/{tokenId}` | `{ "key", "oldValue" }` |
+| POST | `/transaction/{address}/request-update/{tokenId}` | `{ "key", "oldValue", "newValue" }` |
+| GET | `/transaction/{address}/update-token/{tokenId}?request=<ref>` | one `request` query param per request consumed |
+| GET | `/transaction/{address}/retract-change/{requestId}` | requestId is `txHash-index` |
+| GET | `/transaction/{address}/end-token/{tokenId}` | destroy the token |
+| POST | `/transaction` | `{ "signedTransaction" }` → `{ txHash }` |
+| GET | `/transaction?txHash=<hash>` | tx info, 404 if unknown |
+| GET | `/wait/{n}` | wait for n blocks |
+
+The request body field names changed in v1.1.0 (insert `value` → `newValue`,
+delete `value` → `oldValue`). A full worked walkthrough is in
+`docs-mkdocs/manual/signingless.md`.
+
+## Answering questions
+
+- **"What is MPFS / how does it work?"** → README "What is this" and
+  `docs-mkdocs/index.md`; the parties (oracle, requester, observer) and the
+  boot/update/end/retract flow are in `docs-mkdocs/architecture.md`.
+- **"How do I install / run it?"** → README Install/Quickstart and
+  `docs-mkdocs/getting-started.md`. Current image tag: `v1.3.0`.
+- **"What endpoints exist / what body do I send?"** → README Usage table,
+  `docs-mkdocs/swagger-ui.md`, and the routes in `http.ts`. The live OpenAPI is
+  at `https://mpfs.plutimus.com/api-docs`.
+- **"What does the validator enforce?"** → `docs-mkdocs/code/on-chain.md` and
+  `on_chain/validators/cage.ak`.
+- **"How is the off-chain service structured?"** → `docs-mkdocs/code/off-chain.md`
+  and `src/transactions/context.ts`.
+- **Version / history** → `off_chain/CHANGELOG.md` and GitHub releases (latest
+  `v1.3.0`). Note `off_chain/package.json` may lag the release tag.


### PR DESCRIPTION
## Summary

Documentation review of MPFS against the current state of the code. Docs-only
changes — no source, tests, CI, flake, or justfile were touched. Every factual
claim, endpoint, flag, and on-chain type below was verified against the
repository source.

## What was inaccurate (and is now fixed)

**Stale request body fields (the big one).** The signingless manual sent
`{"key","value"}` for insert and delete. Per the handlers in
`off_chain/src/service/signingless/http.ts` and the v1.1.0 entry in
`off_chain/CHANGELOG.md`, insert requires `newValue` and delete requires
`oldValue` (update already used `oldValue`/`newValue`). The examples would not
work as written; they now match the code, with a short note on the rename.

**Image tag.** README and getting-started pulled
`ghcr.io/cardano-foundation/mpfs/mpfs:v1.1.0`. The latest release (and the
matching published image tag) is `v1.3.0` — updated.

**Phantom endpoint.** `swagger-ui.md` listed `GET /tips`, which no route
registers. The tips are returned by `GET /tokens` in `indexerStatus`; the
`/tips` row is removed and the real source noted.

**On-chain types/helpers.** `code/on-chain.md` did not match
`on_chain/validators/types.ak` / `lib.ak`: `MintRedeemer` is
`Minting(Mint)`/`Burning` (not `Boot`/`Destroy`), `UpdateRedeemer` is the sum
`End`/`Contribute`/`Modify`/`Retract` (not a `{proofs}` record), `State.owner`
is a `VerificationKeyHash` and `root` a `ByteArray`, `Operation` and `CageDatum`
are positional, `Request` fields are `requestToken`/`requestOwner`/etc., and the
`lib.ak` helper signatures were wrong. All rewritten to the source.

**Storage engine.** `code/off-chain.md` labelled the state store "SQLite". The
code uses LevelDB (`level` / `abstract-level`). Fixed, and the `Context` type
completed to match `transactions/context.ts`.

**Removed signingful service.** The signingful flavor is no longer in the code
(`off_chain/src/service/signing/` is gone). `index.md` described two flavors and
`getting-started.md` linked a non-existent `manual/signingful.md`. Updated to
describe the signingless service that actually ships and removed the dead link.

**Other:** corrected the from-source clone path (`cd mpfs/off_chain`), and
replaced the README ASCII diagram with an accurate mermaid architecture diagram.

## README to the standard shape

Reordered into the org-standard sections (what is this, architecture, install,
quickstart, usage, documentation, development), with a verified endpoint table
and request-body field names. Preserved existing badges and the Radicle pointer.

## Agent layer

Added `AGENTS.md` and `skills/mpfs-guide/SKILL.md` (repository map, build/test/run
commands, code navigation, HTTP API usage, and where common answers live), plus a
"For AI agents, start at AGENTS.md" pointer in the README.

## mkdocs

Added the light/dark palette toggle (the site was dark-only).

## Verification

- Endpoints/flags checked against `service/signingless/http.ts`, `main.ts`,
  `wallet.ts`; request builders in `src/transactions/`.
- On-chain claims checked against `on_chain/validators/{cage,types,lib}.ak`.
- `mkdocs build --strict` passes cleanly (exit 0, no warnings) — built via the
  flake's mkdocs package (same Material + pymdownx extensions CI uses). The full
  `nix develop` shell builds the cardano-node toolchain and was too slow to use
  for the doc build here.
- Mermaid diagrams validated node-by-node against the code.
